### PR TITLE
Add `PosgreSQL` proposal with `Docker`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ build/
 ### VS Code ###
 .vscode/
 .env
+
+# PostgreSQL
+.data

--- a/README.docker.md
+++ b/README.docker.md
@@ -1,0 +1,33 @@
+# Install Docker and Docker Compose for Ubuntu
+
+## Add Docker's official GPG key
+```
+sudo apt-get update
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+```
+
+## Add the repository to Apt sources
+```
+echo \
+"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+```
+
+## Install Docker Engine, Docker CLI, Containerd and Docker Compose
+```
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo systemctl start docker
+sudo systemctl enable docker
+```
+
+## Start PostgreSQL through Docker
+
+In the projects root directory:
+```
+./start-postgresql.sh
+```

--- a/docker-compose-postgresql.yaml
+++ b/docker-compose-postgresql.yaml
@@ -1,0 +1,13 @@
+services:
+  postgresql:
+    image: postgres:15
+    container_name: amp-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "5433:5432"
+    volumes:
+      - ./data/postgres:/var/lib/postgresql/data

--- a/start-posgresql.sh
+++ b/start-posgresql.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SWD="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+
+docker compose -f "${SWD}/docker-compose-postgresql.yml" up

--- a/start-posgresql.sh
+++ b/start-posgresql.sh
@@ -2,4 +2,4 @@
 
 SWD="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
-docker compose -f "${SWD}/docker-compose-postgresql.yml" up
+docker compose -f "${SWD}/docker-compose-postgresql.yaml" up


### PR DESCRIPTION
Good day hackers! :)

This is just a proposal as I saw that developers "fighting" for resources.

It is a good practice, at least for small & mid-sized teams, that each developer has it's own local instance of a database server.

Pros:
- With `Docker` each developer has an **_identical_** setup of a database server
- Your not clashing about resources like maximum connections
- You work with your own dataset that is not getting modified by others

The first & last point is super important, because the changes in your feature branch you are working on does not may reflect the state of a remote database. If all are using the same remote database and someone changes data records, it may not result only in confusion, but could & will also break your implementation in your feature branch.

And well, again, it's just a proposal. :)